### PR TITLE
Define `in6_ifreq` only if `linux/ipv6.h` is not included

### DIFF
--- a/linux_pytun.c
+++ b/linux_pytun.c
@@ -24,11 +24,13 @@
 #endif
 
 
+#ifndef _UAPI_IPV6_H
 struct in6_ifreq {
     struct in6_addr ifr6_addr;
     __u32 ifr6_prefixlen;
     unsigned int ifr6_ifindex;
 };
+#endif
 
 static PyObject* pytun_error = NULL;
 


### PR DESCRIPTION
When building on termux:
`linux_pytun.c`: `#include <arpa/inet.h>`  
then `arpa/inet.h`: `#include <netinet/in.h>`  
then `netinet/in.h`: `#include <linux/ipv6.h>`  
which resulted in the redefinition of `in6_freq`.
This workaround detects if `linux/ipv6.h` is already included then define `in6_ifreq`.😊