### PR TITLE
Also detect `linux/ipv6.h` by `_IPV6_H`, add push & pull request CI

### DIFF
--- a/.github/workflows/pypi-build-publish.yml
+++ b/.github/workflows/pypi-build-publish.yml
@@ -1,6 +1,10 @@
 name: Build wheels for Linux/macOS, build sdist, and publish to PyPI
 
 on:
+  push:
+    branches: [ 'master' ]
+  pull_request:
+    branches: [ 'master' ]
   release:
     types: published
 
@@ -51,6 +55,7 @@ jobs:
 
   pypi-publish:
     name: Publish release to PyPI
+    if: ${{ github.event_name == 'release' }}
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     environment:

--- a/linux_pytun.c
+++ b/linux_pytun.c
@@ -24,7 +24,7 @@
 #endif
 
 
-#ifndef _UAPI_IPV6_H
+#if !defined(_UAPI_IPV6_H) && !defined(_IPV6_H)
 struct in6_ifreq {
     struct in6_addr ifr6_addr;
     __u32 ifr6_prefixlen;


### PR DESCRIPTION
I found the idea in #14 brings more redefinition in older Linux, so just added `!defined(_IPV6_H)`
 Little changed CI config to handle commit & pull requests and not uploading to PyPI